### PR TITLE
Add FilignsCenter admin and user portals

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FilignsCenter Admin Console</title>
+    <link rel="stylesheet" href="assets/style.css" />
+    <script defer src="assets/storage.js"></script>
+    <script defer src="assets/admin.js"></script>
+  </head>
+  <body>
+    <header>
+      <div class="brand">
+        <div class="brand-logo">FC</div>
+        <div>
+          <h1>FilignsCenter Admin Console</h1>
+          <p>
+            Manage user access, post sizes, categories and templates. Uploaded
+            templates instantly appear in the user portal category-wise.
+          </p>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section id="adminAuth" class="card auth-card">
+        <div>
+          <h2>Administrator login</h2>
+          <p class="helper-text">Default credentials: <strong>admin / admin123</strong></p>
+        </div>
+        <form id="adminLoginForm" class="form-grid">
+          <div class="form-row">
+            <label for="adminUser">User ID</label>
+            <input id="adminUser" name="adminUser" placeholder="admin" required />
+          </div>
+          <div class="form-row">
+            <label for="adminPass">Password</label>
+            <input id="adminPass" name="adminPass" type="password" placeholder="••••••" required />
+          </div>
+          <button type="submit">Login</button>
+        </form>
+        <p class="helper-text">Only admin roles can access this console.</p>
+      </section>
+
+      <section id="adminApp" class="hidden">
+        <article class="card" id="adminSummary">
+          <div style="display: flex; justify-content: space-between; align-items: center; gap: 16px;">
+            <div>
+              <h2>Overview</h2>
+              <p class="muted">
+                Track total users, templates and categories. Changes auto-save to
+                local storage for this prototype.
+              </p>
+            </div>
+            <button type="button" class="secondary" id="adminLogoutBtn">Log out</button>
+          </div>
+          <div class="template-list" id="statsGrid"></div>
+        </article>
+
+        <article class="card">
+          <h2>User management</h2>
+          <p class="helper-text">
+            Create user IDs and passwords. Share credentials with clients so they
+            can login to the creator portal.
+          </p>
+          <form id="userForm" class="form-grid two">
+            <div class="form-row">
+              <label for="newUserId">User ID</label>
+              <input id="newUserId" placeholder="unique id" required />
+            </div>
+            <div class="form-row">
+              <label for="newUserName">Display name</label>
+              <input id="newUserName" placeholder="Client name" />
+            </div>
+            <div class="form-row">
+              <label for="newUserPass">Password</label>
+              <div class="control-row">
+                <input id="newUserPass" type="text" placeholder="Generate strong password" required />
+                <button type="button" class="secondary" id="generatePassBtn">Generate</button>
+              </div>
+            </div>
+            <div class="form-row">
+              <label for="newUserEmail">Default email</label>
+              <input id="newUserEmail" type="email" placeholder="client@email.com" />
+            </div>
+            <div class="form-row">
+              <label for="newUserPhone">Default phone</label>
+              <input id="newUserPhone" placeholder="+91 90000 00000" />
+            </div>
+            <div class="form-row">
+              <label for="newUserTagline">Default tagline</label>
+              <input id="newUserTagline" placeholder="Optional tagline" />
+            </div>
+            <div class="form-row">
+              <label for="newUserAddress">Default address</label>
+              <textarea id="newUserAddress" rows="2" placeholder="Business street, city"></textarea>
+            </div>
+            <div class="form-row">
+              <label>Brand colors</label>
+              <div class="control-row">
+                <input id="newUserColor1" type="color" value="#1e88e5" />
+                <input id="newUserColor2" type="color" value="#f9a825" />
+              </div>
+            </div>
+            <div class="form-row">
+              <label for="newUserLogo">Logo (optional)</label>
+              <input id="newUserLogo" type="file" accept="image/*" />
+            </div>
+            <div class="form-row" style="align-self: end;">
+              <button type="submit">Create user</button>
+            </div>
+          </form>
+          <div id="userList" style="margin-top: 24px; display: grid; gap: 12px;"></div>
+        </article>
+
+        <article class="card">
+          <h2>Post size library</h2>
+          <form id="sizeForm" class="form-grid two">
+            <div class="form-row">
+              <label for="sizePlatform">Platform</label>
+              <input id="sizePlatform" placeholder="Instagram" required />
+            </div>
+            <div class="form-row">
+              <label for="sizeLabel">Label</label>
+              <input id="sizeLabel" placeholder="Story" required />
+            </div>
+            <div class="form-row">
+              <label for="sizeWidth">Width (px)</label>
+              <input id="sizeWidth" type="number" min="100" required />
+            </div>
+            <div class="form-row">
+              <label for="sizeHeight">Height (px)</label>
+              <input id="sizeHeight" type="number" min="100" required />
+            </div>
+            <div class="form-row" style="align-self: end;">
+              <button type="submit">Add size</button>
+            </div>
+          </form>
+          <div id="sizeList" style="margin-top: 20px; display: grid; gap: 12px;"></div>
+        </article>
+
+        <article class="card">
+          <h2>Categories</h2>
+          <form id="categoryForm" class="form-grid two">
+            <div class="form-row">
+              <label for="categoryName">Name</label>
+              <input id="categoryName" placeholder="Instagram Stories" required />
+            </div>
+            <div class="form-row">
+              <label for="categoryDescription">Description</label>
+              <textarea id="categoryDescription" rows="2" placeholder="Short description"></textarea>
+            </div>
+            <div class="form-row">
+              <label>Supported post sizes</label>
+              <div id="categorySizeOptions" style="display: grid; gap: 8px;"></div>
+            </div>
+            <div class="form-row" style="align-self: end;">
+              <button type="submit">Create category</button>
+            </div>
+          </form>
+          <div id="categoryList" style="margin-top: 20px; display: grid; gap: 12px;"></div>
+        </article>
+
+        <article class="card">
+          <h2>Template builder</h2>
+          <p class="helper-text">
+            Paste HTML with <code>data-placeholder</code> attributes for auto-fill.
+            Use quick insert buttons to drop ready placeholders.
+          </p>
+          <form id="templateForm" class="form-grid">
+            <div class="form-grid two">
+              <div class="form-row">
+                <label for="templateTitle">Template title</label>
+                <input id="templateTitle" placeholder="Diwali offer" required />
+              </div>
+              <div class="form-row">
+                <label for="templateCategory">Category</label>
+                <select id="templateCategory" required></select>
+              </div>
+              <div class="form-row">
+                <label for="templateSize">Post size</label>
+                <select id="templateSize" required></select>
+              </div>
+              <div class="form-row">
+                <label for="templateAccent">Accent color</label>
+                <input id="templateAccent" type="color" value="#ff6b6b" />
+              </div>
+            </div>
+            <div class="form-row">
+              <label for="templateFonts">Fonts (comma separated)</label>
+              <input id="templateFonts" placeholder="Poppins, Nunito, Inter" />
+            </div>
+            <div class="form-row">
+              <label for="templateDescription">Short description</label>
+              <textarea id="templateDescription" rows="2" placeholder="Where should this template be used?"></textarea>
+            </div>
+            <div class="form-row">
+              <label>Quick placeholders</label>
+              <div class="control-row" id="placeholderButtons"></div>
+            </div>
+            <div class="form-row">
+              <label for="templateMarkup">Template HTML</label>
+              <textarea id="templateMarkup" rows="10" placeholder="Paste HTML markup with placeholders"></textarea>
+              <p class="helper-text">
+                Example: <code>&lt;h2 data-placeholder="name" data-editable="true"&gt;Brand&lt;/h2&gt;</code>
+              </p>
+            </div>
+            <div class="profile-actions">
+              <button type="button" class="secondary" id="loadBaseTemplateBtn">Load sample layout</button>
+              <button type="submit" id="saveTemplateBtn">Save template</button>
+            </div>
+          </form>
+          <div style="margin-top: 24px; display: grid; gap: 16px;">
+            <div>
+              <h3 style="margin: 0 0 8px 0;">Live preview</h3>
+              <div id="templatePreview" style="background: #f3f4f6; padding: 24px; border-radius: 18px; min-height: 280px; border: 1px dashed var(--border);"></div>
+            </div>
+            <div>
+              <h3 style="margin: 0 0 8px 0;">Existing templates</h3>
+              <div id="templateListAdmin" style="display: grid; gap: 12px;"></div>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <div id="adminToast" class="toast"></div>
+  </body>
+</html>

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -1,0 +1,677 @@
+const AdminApp = (() => {
+  const state = {
+    admin: null,
+    editingTemplateId: null,
+    currentData: null
+  };
+
+  const placeholderPresets = [
+    { key: 'name', label: 'Name', snippet: '<span data-placeholder="name" data-editable="true">Brand name</span>' },
+    { key: 'phone', label: 'Phone', snippet: '<span data-placeholder="phone" data-editable="true">+91 90000 00000</span>' },
+    { key: 'email', label: 'Email', snippet: '<span data-placeholder="email" data-editable="true">mail@brand.com</span>' },
+    { key: 'address', label: 'Address', snippet: '<span data-placeholder="address" data-editable="true">Business street, city</span>' },
+    { key: 'tagline', label: 'Tagline', snippet: '<span data-placeholder="tagline" data-editable="true">Creative tagline</span>' },
+    { key: 'logo', label: 'Logo', snippet: `<img data-placeholder="logo" src="${FilignsStorage.defaultLogo}" alt="Brand logo" class="fc-logo" />` }
+  ];
+
+  const selectors = {};
+
+  const lightenColor = (hex, amount = 0.2) => {
+    if (!hex) return '#ffffff';
+    const clean = hex.replace('#', '');
+    const num = parseInt(clean, 16);
+    const r = Math.min(255, Math.floor(((num >> 16) & 0xff) + 255 * amount));
+    const g = Math.min(255, Math.floor(((num >> 8) & 0xff) + 255 * amount));
+    const b = Math.min(255, Math.floor((num & 0xff) + 255 * amount));
+    return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
+  };
+
+  const showToast = (message) => {
+    const toast = document.getElementById('adminToast');
+    if (!toast) return;
+    toast.textContent = message;
+    toast.classList.add('show');
+    setTimeout(() => toast.classList.remove('show'), 3200);
+  };
+
+  const readFileAsDataURL = (file) => {
+    if (!file) return Promise.resolve(null);
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  };
+
+  const renderStats = () => {
+    const { currentData } = state;
+    const statsGrid = document.getElementById('statsGrid');
+    if (!statsGrid) return;
+    const statTemplates = [
+      {
+        label: 'Total users',
+        value: currentData.users.filter((u) => u.role !== 'admin').length,
+        hint: 'Active creator accounts'
+      },
+      {
+        label: 'Templates',
+        value: currentData.templates.length,
+        hint: 'Published layouts ready to use'
+      },
+      {
+        label: 'Categories',
+        value: currentData.categories.length,
+        hint: 'Grouped by campaign type'
+      },
+      {
+        label: 'Post sizes',
+        value: currentData.postSizes.length,
+        hint: 'Platform specific dimensions'
+      }
+    ];
+
+    statsGrid.innerHTML = statTemplates
+      .map(
+        (stat) => `
+          <div class="template-card" style="cursor: default;">
+            <h3>${stat.value}</h3>
+            <p>${stat.label}</p>
+            <span class="badge">${stat.hint}</span>
+          </div>
+        `
+      )
+      .join('');
+  };
+
+  const renderUsers = () => {
+    const list = document.getElementById('userList');
+    if (!list) return;
+    const { currentData } = state;
+    if (!currentData.users.length) {
+      list.innerHTML = '<p class="muted">No users created yet.</p>';
+      return;
+    }
+
+    list.innerHTML = currentData.users
+      .filter((u) => u.role !== 'admin')
+      .map((user) => {
+        const savedCount = user.savedTemplates ? user.savedTemplates.length : 0;
+        return `
+          <div class="saved-card" data-user="${user.id}">
+            <div>
+              <h4>${user.name || user.id}</h4>
+              <p class="muted">ID: <code>${user.id}</code> • Saved designs: ${savedCount}</p>
+            </div>
+            <div class="control-row">
+              <button type="button" class="secondary" data-action="reset" data-user="${user.id}">Reset password</button>
+              <button type="button" class="secondary" data-action="delete" data-user="${user.id}">Delete</button>
+            </div>
+          </div>
+        `;
+      })
+      .join('');
+  };
+
+  const renderSizes = () => {
+    const list = document.getElementById('sizeList');
+    if (!list) return;
+    const { currentData } = state;
+    if (!currentData.postSizes.length) {
+      list.innerHTML = '<p class="muted">No custom sizes yet.</p>';
+      return;
+    }
+
+    list.innerHTML = currentData.postSizes
+      .map(
+        (size) => `
+        <div class="saved-card" data-size="${size.id}">
+          <div>
+            <h4>${size.platform} · ${size.label}</h4>
+            <p class="muted">${size.width} × ${size.height}px</p>
+          </div>
+          <button type="button" class="secondary" data-action="delete-size" data-size="${size.id}">Remove</button>
+        </div>
+      `
+      )
+      .join('');
+
+    renderCategorySizeOptions();
+  };
+
+  const renderCategorySizeOptions = () => {
+    const optionsWrapper = document.getElementById('categorySizeOptions');
+    if (!optionsWrapper) return;
+    const { currentData } = state;
+    optionsWrapper.innerHTML = currentData.postSizes
+      .map(
+        (size) => `
+        <label style="display:flex; align-items:center; gap:8px;">
+          <input type="checkbox" value="${size.id}" />
+          <span>${size.platform} · ${size.label} (${size.width}×${size.height})</span>
+        </label>
+      `
+      )
+      .join('');
+
+    populateTemplateSelectors();
+  };
+
+  const renderCategories = () => {
+    const list = document.getElementById('categoryList');
+    if (!list) return;
+    const { currentData } = state;
+    if (!currentData.categories.length) {
+      list.innerHTML = '<p class="muted">No categories created yet.</p>';
+      return;
+    }
+
+    const sizeMap = new Map(currentData.postSizes.map((size) => [size.id, size]));
+
+    list.innerHTML = currentData.categories
+      .map((cat) => {
+        const sizeBadges = (cat.postSizeIds || [])
+          .map((id) => {
+            const item = sizeMap.get(id);
+            if (!item) return '';
+            return `<span class="badge">${item.platform} · ${item.label}</span>`;
+          })
+          .join(' ');
+        return `
+          <div class="saved-card" data-category="${cat.id}">
+            <div>
+              <h4>${cat.name}</h4>
+              <p class="muted">${cat.description || '—'}</p>
+              <div style="display:flex; flex-wrap:wrap; gap:8px; margin-top:8px;">${sizeBadges}</div>
+            </div>
+            <button type="button" class="secondary" data-action="delete-category" data-category="${cat.id}">Delete</button>
+          </div>
+        `;
+      })
+      .join('');
+
+    populateTemplateSelectors();
+  };
+
+  const renderTemplatePreview = () => {
+    const preview = document.getElementById('templatePreview');
+    const markup = selectors.templateMarkup.value.trim();
+    if (!preview) return;
+    if (!markup) {
+      preview.innerHTML = '<p class="muted">Preview will appear here once you add HTML markup.</p>';
+      return;
+    }
+
+    preview.innerHTML = markup;
+  };
+
+  const renderTemplates = () => {
+    const list = document.getElementById('templateListAdmin');
+    if (!list) return;
+    const { currentData } = state;
+    if (!currentData.templates.length) {
+      list.innerHTML = '<p class="muted">No templates yet. Create one using the builder above.</p>';
+      return;
+    }
+
+    const categoryMap = new Map(currentData.categories.map((cat) => [cat.id, cat]));
+    const sizeMap = new Map(currentData.postSizes.map((size) => [size.id, size]));
+
+    list.innerHTML = currentData.templates
+      .map((template) => {
+        const category = categoryMap.get(template.categoryId);
+        const size = sizeMap.get(template.postSizeId);
+        const gradient = template.thumbnailColor
+          ? `linear-gradient(135deg, ${template.thumbnailColor[0]}, ${template.thumbnailColor[1] || lightenColor(template.accent, 0.3)})`
+          : `linear-gradient(135deg, ${template.accent}, ${lightenColor(template.accent, 0.25)})`;
+        return `
+          <div class="saved-card" data-template="${template.id}" style="background: ${gradient}; color: #fff;">
+            <div>
+              <h4>${template.title}</h4>
+              <p class="muted" style="color: rgba(255,255,255,0.8);">${category ? category.name : 'Unassigned'} • ${
+          size ? `${size.platform} · ${size.label}` : 'Size missing'
+        }</p>
+            </div>
+            <div class="control-row">
+              <button type="button" class="secondary" data-action="edit-template" data-template="${template.id}">Edit</button>
+              <button type="button" class="secondary" data-action="delete-template" data-template="${template.id}">Delete</button>
+            </div>
+          </div>
+        `;
+      })
+      .join('');
+  };
+
+  const populateTemplateSelectors = () => {
+    if (!selectors.templateCategory || !selectors.templateSize) return;
+    const { currentData } = state;
+    selectors.templateCategory.innerHTML = currentData.categories
+      .map((cat) => `<option value="${cat.id}">${cat.name}</option>`)
+      .join('');
+    selectors.templateSize.innerHTML = currentData.postSizes
+      .map((size) => `<option value="${size.id}">${size.platform} · ${size.label}</option>`)
+      .join('');
+  };
+
+  const insertAtCursor = (textarea, text) => {
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const value = textarea.value;
+    textarea.value = value.slice(0, start) + text + value.slice(end);
+    const newCursor = start + text.length;
+    textarea.setSelectionRange(newCursor, newCursor);
+    textarea.focus();
+    renderTemplatePreview();
+  };
+
+  const bindPlaceholderButtons = () => {
+    const container = document.getElementById('placeholderButtons');
+    if (!container) return;
+    container.innerHTML = placeholderPresets
+      .map((preset) => `<button type="button" class="secondary" data-placeholder="${preset.key}">${preset.label}</button>`)
+      .join('');
+
+    container.addEventListener('click', (event) => {
+      const target = event.target.closest('button[data-placeholder]');
+      if (!target) return;
+      const preset = placeholderPresets.find((item) => item.key === target.dataset.placeholder);
+      if (preset) {
+        insertAtCursor(selectors.templateMarkup, preset.snippet);
+      }
+    });
+  };
+
+  const loadSampleTemplate = () => {
+    const accent = selectors.templateAccent.value || '#ff6b6b';
+    const lighter = lightenColor(accent, 0.3);
+    const markup = `
+<div class="fc-canvas fc-square" style="--accent-color:${accent}; --secondary-color:${lighter};">
+  <div class="fc-header">
+    <div class="fc-logo-wrapper">
+      <img data-placeholder="logo" src="${FilignsStorage.defaultLogo}" alt="Logo" class="fc-logo" />
+    </div>
+    <div class="fc-headline">
+      <p class="fc-tag" data-editable="true">Limited Time</p>
+      <h1 data-placeholder="name" data-editable="true">Brand headline</h1>
+      <p data-placeholder="tagline" data-editable="true">Add an optional supporting line</p>
+    </div>
+  </div>
+  <div class="fc-body">
+    <div class="fc-sale-block">
+      <span class="fc-sale-label" data-editable="true">FLAT</span>
+      <span class="fc-sale-value" data-editable="true">40% OFF</span>
+    </div>
+    <div class="fc-contact">
+      <p><span class="fc-contact-label">Call:</span> <span data-placeholder="phone" data-editable="true">+91 90000 00000</span></p>
+      <p><span class="fc-contact-label">Email:</span> <span data-placeholder="email" data-editable="true">hello@brand.com</span></p>
+      <p><span class="fc-contact-label">Visit:</span> <span data-placeholder="address" data-editable="true">Business street, city</span></p>
+    </div>
+  </div>
+  <div class="fc-footer" data-editable="true">Update fonts, colors, text & logo once uploaded.</div>
+</div>`;
+    selectors.templateMarkup.value = markup.trim();
+    selectors.templateFonts.value = 'Poppins, Montserrat, Nunito';
+    renderTemplatePreview();
+  };
+
+  const collectTemplateData = () => {
+    const title = selectors.templateTitle.value.trim();
+    const categoryId = selectors.templateCategory.value;
+    const postSizeId = selectors.templateSize.value;
+    const accent = selectors.templateAccent.value || '#ff6b6b';
+    const fonts = selectors.templateFonts.value
+      .split(',')
+      .map((font) => font.trim())
+      .filter(Boolean);
+    const description = selectors.templateDescription.value.trim();
+    const htmlContent = selectors.templateMarkup.value.trim();
+    if (!title || !categoryId || !postSizeId || !htmlContent) {
+      showToast('Please fill the required template fields.');
+      return null;
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = htmlContent;
+    const placeholderSet = new Set();
+    wrapper.querySelectorAll('[data-placeholder]').forEach((node) => {
+      if (node.dataset.placeholder) {
+        placeholderSet.add(node.dataset.placeholder);
+      }
+    });
+
+    const template = {
+      id: state.editingTemplateId || FilignsStorage.generateId('temp'),
+      title,
+      categoryId,
+      postSizeId,
+      accent,
+      fonts,
+      description,
+      htmlContent,
+      placeholders: Array.from(placeholderSet),
+      thumbnailColor: [accent, lightenColor(accent, 0.25)]
+    };
+
+    return template;
+  };
+
+  const resetTemplateForm = () => {
+    state.editingTemplateId = null;
+    selectors.templateForm.reset();
+    selectors.templateMarkup.value = '';
+    selectors.templateFonts.value = '';
+    selectors.templateAccent.value = '#ff6b6b';
+    renderTemplatePreview();
+    selectors.saveTemplateBtn.textContent = 'Save template';
+  };
+
+  const hydrateTemplateForm = (template) => {
+    state.editingTemplateId = template.id;
+    selectors.templateTitle.value = template.title;
+    selectors.templateCategory.value = template.categoryId;
+    selectors.templateSize.value = template.postSizeId;
+    selectors.templateAccent.value = template.accent || '#ff6b6b';
+    selectors.templateFonts.value = (template.fonts || []).join(', ');
+    selectors.templateDescription.value = template.description || '';
+    selectors.templateMarkup.value = template.htmlContent;
+    renderTemplatePreview();
+    selectors.saveTemplateBtn.textContent = 'Update template';
+  };
+
+  const attachEventHandlers = () => {
+    const adminLoginForm = document.getElementById('adminLoginForm');
+    const adminLogoutBtn = document.getElementById('adminLogoutBtn');
+
+    adminLoginForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const username = document.getElementById('adminUser').value.trim();
+      const password = document.getElementById('adminPass').value.trim();
+      const data = FilignsStorage.loadData();
+      const admin = data.users.find((user) => user.id === username && user.password === password && user.role === 'admin');
+      if (!admin) {
+        showToast('Invalid admin credentials.');
+        return;
+      }
+      state.admin = admin;
+      state.currentData = data;
+      localStorage.setItem('fc_admin_session', username);
+      document.getElementById('adminAuth').classList.add('hidden');
+      document.getElementById('adminApp').classList.remove('hidden');
+      selectors.templateFonts.value = data.settings?.fonts?.join(', ') || '';
+      renderAll();
+      showToast(`Welcome back, ${admin.name || admin.id}!`);
+    });
+
+    if (adminLogoutBtn) {
+      adminLogoutBtn.addEventListener('click', () => {
+        state.admin = null;
+        state.currentData = null;
+        localStorage.removeItem('fc_admin_session');
+        document.getElementById('adminAuth').classList.remove('hidden');
+        document.getElementById('adminApp').classList.add('hidden');
+      });
+    }
+
+    document.getElementById('generatePassBtn').addEventListener('click', () => {
+      const random = Math.random().toString(36).slice(2, 10);
+      document.getElementById('newUserPass').value = random;
+    });
+
+    document.getElementById('userList').addEventListener('click', (event) => {
+      const resetBtn = event.target.closest('button[data-action="reset"]');
+      const deleteBtn = event.target.closest('button[data-action="delete"]');
+      if (resetBtn) {
+        const userId = resetBtn.dataset.user;
+        const newPassword = Math.random().toString(36).slice(2, 10);
+        state.currentData = FilignsStorage.updateData((data) => {
+          const user = data.users.find((u) => u.id === userId);
+          if (user) {
+            user.password = newPassword;
+          }
+          state.currentData = data;
+        });
+        renderUsers();
+        showToast(`Password reset to ${newPassword}`);
+      }
+      if (deleteBtn) {
+        const userId = deleteBtn.dataset.user;
+        state.currentData = FilignsStorage.updateData((data) => {
+          data.users = data.users.filter((u) => u.id !== userId);
+          state.currentData = data;
+        });
+        renderUsers();
+        renderStats();
+        showToast('User deleted.');
+      }
+    });
+
+    document.getElementById('userForm').addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const id = document.getElementById('newUserId').value.trim();
+      const name = document.getElementById('newUserName').value.trim();
+      const password = document.getElementById('newUserPass').value.trim();
+      const email = document.getElementById('newUserEmail').value.trim();
+      const phone = document.getElementById('newUserPhone').value.trim();
+      const tagline = document.getElementById('newUserTagline').value.trim();
+      const address = document.getElementById('newUserAddress').value.trim();
+      const color1 = document.getElementById('newUserColor1').value;
+      const color2 = document.getElementById('newUserColor2').value;
+      const logoInput = document.getElementById('newUserLogo');
+
+      if (!id || !password) {
+        showToast('User ID and password are required.');
+        return;
+      }
+
+      if (state.currentData.users.some((user) => user.id === id)) {
+        showToast('User ID already exists. Choose a unique ID.');
+        return;
+      }
+
+      const logo = await readFileAsDataURL(logoInput.files[0]).catch(() => null);
+
+      state.currentData = FilignsStorage.updateData((data) => {
+        data.users.push({
+          id,
+          name: name || id,
+          role: 'user',
+          password,
+          profile: {
+            name: name || id,
+            email,
+            phone,
+            tagline,
+            address,
+            colorPrimary: color1,
+            colorSecondary: color2,
+            logo: logo || FilignsStorage.defaultLogo
+          },
+          savedTemplates: []
+        });
+        state.currentData = data;
+      });
+
+      event.target.reset();
+      renderUsers();
+      renderStats();
+      showToast(`User ${id} created.`);
+    });
+
+    document.getElementById('sizeForm').addEventListener('submit', (event) => {
+      event.preventDefault();
+      const platform = document.getElementById('sizePlatform').value.trim();
+      const label = document.getElementById('sizeLabel').value.trim();
+      const width = Number(document.getElementById('sizeWidth').value);
+      const height = Number(document.getElementById('sizeHeight').value);
+      if (!platform || !label || !width || !height) {
+        showToast('Please fill all post size fields.');
+        return;
+      }
+      state.currentData = FilignsStorage.updateData((data) => {
+        data.postSizes.push({
+          id: FilignsStorage.generateId('size'),
+          platform,
+          label,
+          width,
+          height
+        });
+        state.currentData = data;
+      });
+      event.target.reset();
+      renderSizes();
+      renderStats();
+      showToast('Post size added.');
+    });
+
+    document.getElementById('sizeList').addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-action="delete-size"]');
+      if (!button) return;
+      const id = button.dataset.size;
+      state.currentData = FilignsStorage.updateData((data) => {
+        data.postSizes = data.postSizes.filter((size) => size.id !== id);
+        state.currentData = data;
+      });
+      renderSizes();
+      renderCategories();
+      renderTemplates();
+      renderStats();
+      showToast('Post size removed.');
+    });
+
+    document.getElementById('categoryForm').addEventListener('submit', (event) => {
+      event.preventDefault();
+      const name = document.getElementById('categoryName').value.trim();
+      if (!name) {
+        showToast('Category name is required.');
+        return;
+      }
+      const description = document.getElementById('categoryDescription').value.trim();
+      const selectedSizeIds = Array.from(document.querySelectorAll('#categorySizeOptions input:checked')).map(
+        (input) => input.value
+      );
+      state.currentData = FilignsStorage.updateData((data) => {
+        data.categories.push({
+          id: FilignsStorage.generateId('cat'),
+          name,
+          description,
+          postSizeIds: selectedSizeIds
+        });
+        state.currentData = data;
+      });
+      event.target.reset();
+      renderCategories();
+      renderStats();
+      showToast('Category created.');
+    });
+
+    document.getElementById('categoryList').addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-action="delete-category"]');
+      if (!button) return;
+      const id = button.dataset.category;
+      state.currentData = FilignsStorage.updateData((data) => {
+        data.categories = data.categories.filter((cat) => cat.id !== id);
+        state.currentData = data;
+      });
+      renderCategories();
+      renderTemplates();
+      renderStats();
+      showToast('Category removed.');
+    });
+
+    document.getElementById('templateForm').addEventListener('submit', (event) => {
+      event.preventDefault();
+      const template = collectTemplateData();
+      if (!template) return;
+      state.currentData = FilignsStorage.updateData((data) => {
+        const index = data.templates.findIndex((item) => item.id === template.id);
+        if (index >= 0) {
+          data.templates[index] = template;
+        } else {
+          data.templates.push(template);
+        }
+        state.currentData = data;
+      });
+      renderTemplates();
+      renderStats();
+      resetTemplateForm();
+      showToast('Template saved.');
+    });
+
+    document.getElementById('templateListAdmin').addEventListener('click', (event) => {
+      const editBtn = event.target.closest('button[data-action="edit-template"]');
+      const deleteBtn = event.target.closest('button[data-action="delete-template"]');
+      if (editBtn) {
+        const id = editBtn.dataset.template;
+        const template = state.currentData.templates.find((item) => item.id === id);
+        if (template) {
+          hydrateTemplateForm(template);
+        }
+      }
+      if (deleteBtn) {
+        const id = deleteBtn.dataset.template;
+        state.currentData = FilignsStorage.updateData((data) => {
+          data.templates = data.templates.filter((item) => item.id !== id);
+          state.currentData = data;
+        });
+        renderTemplates();
+        renderStats();
+        showToast('Template deleted.');
+      }
+    });
+
+    selectors.templateMarkup.addEventListener('input', renderTemplatePreview);
+    selectors.templateAccent.addEventListener('input', renderTemplatePreview);
+    document.getElementById('loadBaseTemplateBtn').addEventListener('click', loadSampleTemplate);
+    selectors.templateCategory.addEventListener('change', () => {
+      selectors.templateForm.dataset.changed = 'true';
+    });
+  };
+
+  const renderAll = () => {
+    state.currentData = FilignsStorage.loadData();
+    renderStats();
+    renderUsers();
+    renderSizes();
+    renderCategories();
+    renderTemplates();
+    renderTemplatePreview();
+  };
+
+  const restoreAdminSession = () => {
+    const sessionId = localStorage.getItem('fc_admin_session');
+    if (!sessionId) return;
+    const data = FilignsStorage.loadData();
+    const admin = data.users.find((user) => user.id === sessionId && user.role === 'admin');
+    if (!admin) return;
+    state.admin = admin;
+    state.currentData = data;
+    document.getElementById('adminAuth').classList.add('hidden');
+    document.getElementById('adminApp').classList.remove('hidden');
+    renderAll();
+    showToast(`Welcome back, ${admin.name || admin.id}!`);
+  };
+
+  const init = () => {
+    FilignsStorage.ensureData();
+    selectors.templateForm = document.getElementById('templateForm');
+    selectors.templateTitle = document.getElementById('templateTitle');
+    selectors.templateCategory = document.getElementById('templateCategory');
+    selectors.templateSize = document.getElementById('templateSize');
+    selectors.templateAccent = document.getElementById('templateAccent');
+    selectors.templateFonts = document.getElementById('templateFonts');
+    selectors.templateDescription = document.getElementById('templateDescription');
+    selectors.templateMarkup = document.getElementById('templateMarkup');
+    selectors.saveTemplateBtn = document.getElementById('saveTemplateBtn');
+
+    bindPlaceholderButtons();
+    attachEventHandlers();
+    restoreAdminSession();
+    renderTemplatePreview();
+  };
+
+  return { init };
+})();
+
+document.addEventListener('DOMContentLoaded', () => {
+  AdminApp.init();
+});

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,664 @@
+const FilignsApp = (() => {
+  const STORAGE_SESSION_KEY = 'fc_active_user';
+
+  const state = {
+    currentUserId: null,
+    currentUser: null,
+    data: null,
+    selectedTemplate: null,
+    selectedElement: null,
+    activeSavedDesignId: null
+  };
+
+  const selectors = {};
+
+  const showToast = (message) => {
+    const toast = document.getElementById('toast');
+    if (!toast) return;
+    toast.textContent = message;
+    toast.classList.add('show');
+    setTimeout(() => toast.classList.remove('show'), 3200);
+  };
+
+  const readFileAsDataURL = (file) => {
+    if (!file) return Promise.resolve(null);
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  };
+
+  const getDefaultProfile = (user) => ({
+    name: user?.profile?.name || user?.name || user?.id || '',
+    email: user?.profile?.email || '',
+    phone: user?.profile?.phone || '',
+    tagline: user?.profile?.tagline || '',
+    address: user?.profile?.address || '',
+    colorPrimary: user?.profile?.colorPrimary || '#1e88e5',
+    colorSecondary: user?.profile?.colorSecondary || '#f9a825',
+    logo: user?.profile?.logo || FilignsStorage.defaultLogo
+  });
+
+  const updateColorSwatches = (profile) => {
+    const primary = document.getElementById('swatchPrimary');
+    const secondary = document.getElementById('swatchSecondary');
+    if (primary) primary.style.background = profile.colorPrimary || '#1e88e5';
+    if (secondary) secondary.style.background = profile.colorSecondary || '#f9a825';
+  };
+
+  const populateProfileForm = () => {
+    const profile = getDefaultProfile(state.currentUser);
+    selectors.profileName.value = profile.name;
+    selectors.profileEmail.value = profile.email;
+    selectors.profilePhone.value = profile.phone;
+    selectors.profileTagline.value = profile.tagline;
+    selectors.profileAddress.value = profile.address;
+    selectors.brandPrimary.value = profile.colorPrimary || '#1e88e5';
+    selectors.brandSecondary.value = profile.colorSecondary || '#f9a825';
+    updateColorSwatches(profile);
+  };
+
+  const saveProfile = async (options = {}) => {
+    const logoUpload = document.getElementById('logoUpload');
+    let logo = state.currentUser.profile?.logo || FilignsStorage.defaultLogo;
+    if (options.reset) {
+      logo = FilignsStorage.defaultLogo;
+    } else if (logoUpload.files && logoUpload.files[0]) {
+      logo = (await readFileAsDataURL(logoUpload.files[0]).catch(() => null)) || logo;
+    }
+
+    const updatedProfile = {
+      name: selectors.profileName.value.trim(),
+      email: selectors.profileEmail.value.trim(),
+      phone: selectors.profilePhone.value.trim(),
+      tagline: selectors.profileTagline.value.trim(),
+      address: selectors.profileAddress.value.trim(),
+      colorPrimary: selectors.brandPrimary.value || '#1e88e5',
+      colorSecondary: selectors.brandSecondary.value || '#f9a825',
+      logo
+    };
+
+    state.data = FilignsStorage.updateData((data) => {
+      const user = data.users.find((item) => item.id === state.currentUserId);
+      if (!user) return;
+      user.profile = updatedProfile;
+      state.currentUser = user;
+    });
+    if (logoUpload) logoUpload.value = '';
+    updateColorSwatches(updatedProfile);
+    if (state.selectedTemplate) {
+      applyProfileToCanvas(state.selectedTemplate.canvas, updatedProfile);
+    }
+    showToast('Profile saved.');
+  };
+
+  const logout = () => {
+    localStorage.removeItem(STORAGE_SESSION_KEY);
+    document.getElementById('appSection').classList.add('hidden');
+    document.getElementById('authSection').classList.remove('hidden');
+    state.currentUserId = null;
+    state.currentUser = null;
+    state.selectedTemplate = null;
+    state.selectedElement = null;
+    selectors.canvasStage.innerHTML = '<p class="muted">Select a template from the gallery to start editing.</p>';
+  };
+
+  const applyProfileToCanvas = (canvas, profile) => {
+    if (!canvas) return;
+    const values = {
+      name: profile.name,
+      email: profile.email,
+      phone: profile.phone,
+      address: profile.address,
+      tagline: profile.tagline
+    };
+    canvas.style.setProperty('--brand-primary', profile.colorPrimary || '#1e88e5');
+    canvas.style.setProperty('--brand-secondary', profile.colorSecondary || '#f9a825');
+    canvas.querySelectorAll('[data-placeholder]').forEach((node) => {
+      const key = node.dataset.placeholder;
+      if (!key) return;
+      if (node.tagName.toLowerCase() === 'img') {
+        node.src = profile.logo || FilignsStorage.defaultLogo;
+        return;
+      }
+      if (values[key]) {
+        node.textContent = values[key];
+      }
+    });
+  };
+
+  const deselectElement = () => {
+    if (state.selectedElement) {
+      state.selectedElement.classList.remove('selected-element');
+    }
+    state.selectedElement = null;
+    selectors.fontFamily.disabled = true;
+    selectors.fontSize.disabled = true;
+    selectors.fontColor.disabled = true;
+    selectors.boldBtn.disabled = true;
+    selectors.italicBtn.disabled = true;
+    selectors.alignmentButtons.forEach((btn) => btn.classList.remove('active'));
+    selectors.imageControl.classList.add('hidden');
+  };
+
+  const selectElement = (element) => {
+    if (state.selectedElement === element) return;
+    if (state.selectedElement) {
+      state.selectedElement.classList.remove('selected-element');
+    }
+    state.selectedElement = element;
+    if (!element) {
+      deselectElement();
+      return;
+    }
+    element.classList.add('selected-element');
+
+    const style = window.getComputedStyle(element);
+    const fontName = style.fontFamily.split(',')[0].replace(/"/g, '').trim();
+    ensureFontOption(fontName);
+    selectors.fontFamily.value = fontName;
+    selectors.fontSize.value = parseInt(style.fontSize, 10) || 32;
+    selectors.fontSizeLabel.textContent = `${selectors.fontSize.value}px`;
+    selectors.fontColor.value = rgbToHex(style.color || '#111827');
+    selectors.fontFamily.disabled = false;
+    selectors.fontSize.disabled = false;
+    selectors.fontColor.disabled = false;
+    selectors.boldBtn.disabled = false;
+    selectors.italicBtn.disabled = false;
+
+    const weight = parseInt(style.fontWeight, 10);
+    selectors.boldBtn.classList.toggle('active', weight >= 600);
+    selectors.italicBtn.classList.toggle('active', style.fontStyle === 'italic');
+
+    const align = style.textAlign;
+    selectors.alignmentButtons.forEach((btn) => {
+      btn.classList.toggle('active', btn.dataset.align === align);
+      btn.disabled = false;
+    });
+
+    if (element.tagName.toLowerCase() === 'img') {
+      selectors.imageControl.classList.remove('hidden');
+      selectors.fontFamily.disabled = true;
+      selectors.fontSize.disabled = true;
+      selectors.fontColor.disabled = true;
+      selectors.boldBtn.disabled = true;
+      selectors.italicBtn.disabled = true;
+      selectors.alignmentButtons.forEach((btn) => (btn.disabled = true));
+    } else {
+      selectors.imageControl.classList.add('hidden');
+    }
+  };
+
+  const rgbToHex = (rgb) => {
+    if (!rgb) return '#111827';
+    if (rgb.startsWith('#')) return rgb;
+    const values = rgb.match(/\d+/g);
+    if (!values || values.length < 3) return '#111827';
+    const [r, g, b] = values.map((val) => Number(val));
+    return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
+  };
+
+  const prepareEditableElements = (canvas) => {
+    deselectElement();
+    const editableNodes = canvas.querySelectorAll('[data-editable], [data-placeholder]');
+    editableNodes.forEach((node) => {
+      if (node.tagName.toLowerCase() !== 'img') {
+        node.setAttribute('contenteditable', 'true');
+        node.addEventListener('focus', (event) => {
+          event.stopPropagation();
+          selectElement(node);
+        });
+        node.addEventListener('click', (event) => {
+          event.stopPropagation();
+          selectElement(node);
+        });
+      } else {
+        node.addEventListener('click', (event) => {
+          event.stopPropagation();
+          selectElement(node);
+        });
+      }
+    });
+    canvas.addEventListener('click', () => deselectElement());
+  };
+
+  const loadTemplate = (templateId, options = {}) => {
+    const template = state.data.templates.find((item) => item.id === templateId);
+    if (!template) return;
+    const profile = getDefaultProfile(state.currentUser);
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = (options.htmlOverride || template.htmlContent || '').trim();
+    const canvas = wrapper.firstElementChild;
+    if (!canvas) {
+      showToast('Template markup is empty.');
+      return;
+    }
+
+    if (options.useProfile === false) {
+      canvas.style.setProperty('--brand-primary', profile.colorPrimary || '#1e88e5');
+      canvas.style.setProperty('--brand-secondary', profile.colorSecondary || '#f9a825');
+    } else {
+      applyProfileToCanvas(canvas, profile);
+    }
+
+    prepareEditableElements(canvas);
+
+    selectors.canvasStage.innerHTML = '';
+    const container = document.createElement('div');
+    container.className = 'canvas-wrapper';
+    container.appendChild(canvas);
+    selectors.canvasStage.appendChild(container);
+
+    state.selectedTemplate = {
+      template,
+      canvas,
+      container,
+      fonts: template.fonts || [],
+      savedDesignId: options.savedDesignId || null
+    };
+    state.activeSavedDesignId = options.savedDesignId || null;
+    deselectElement();
+    populateFontControl(template.fonts);
+    showToast(`${template.title} loaded. Start customizing!`);
+  };
+
+  const populateFontControl = (templateFonts = []) => {
+    const globalFonts = state.data.settings?.fonts || [];
+    const fonts = Array.from(new Set([...templateFonts, ...globalFonts]));
+    selectors.fontFamily.innerHTML = fonts
+      .map((font) => `<option value="${font}">${font}</option>`)
+      .join('');
+    selectors.fontFamily.disabled = true;
+    selectors.fontSize.disabled = true;
+    selectors.fontColor.disabled = true;
+    selectors.boldBtn.disabled = true;
+    selectors.italicBtn.disabled = true;
+    selectors.alignmentButtons.forEach((btn) => (btn.disabled = true));
+  };
+
+  const ensureFontOption = (font) => {
+    if (!font) return;
+    const hasOption = Array.from(selectors.fontFamily.options || []).some((option) => option.value === font);
+    if (!hasOption) {
+      const option = document.createElement('option');
+      option.value = font;
+      option.textContent = font;
+      selectors.fontFamily.appendChild(option);
+    }
+  };
+
+  const renderCategoryFilters = () => {
+    const container = document.getElementById('categoryFilters');
+    const categories = state.data.categories;
+    container.innerHTML = categories
+      .map((cat) => `<div class="pill" data-filter="${cat.id}">${cat.name}</div>`)
+      .join('');
+  };
+
+  const renderSizeFilter = () => {
+    selectors.sizeFilter.innerHTML = '<option value="all">All post sizes</option>';
+    state.data.postSizes.forEach((size) => {
+      const option = document.createElement('option');
+      option.value = size.id;
+      option.textContent = `${size.platform} · ${size.label}`;
+      selectors.sizeFilter.appendChild(option);
+    });
+  };
+
+  const renderTemplates = () => {
+    const list = document.getElementById('templateList');
+    const filters = {
+      category: selectors.currentCategoryFilter || 'all',
+      size: selectors.sizeFilter.value || 'all',
+      search: selectors.searchTemplate.value.trim().toLowerCase()
+    };
+
+    const categoryMap = new Map(state.data.categories.map((cat) => [cat.id, cat]));
+    const sizeMap = new Map(state.data.postSizes.map((size) => [size.id, size]));
+
+    const filtered = state.data.templates.filter((template) => {
+      if (filters.category !== 'all' && template.categoryId !== filters.category) return false;
+      if (filters.size !== 'all' && template.postSizeId !== filters.size) return false;
+      if (filters.search && !template.title.toLowerCase().includes(filters.search)) return false;
+      return true;
+    });
+
+    if (!filtered.length) {
+      list.innerHTML = '<p class="muted">No templates found. Adjust filters.</p>';
+      return;
+    }
+
+    list.innerHTML = filtered
+      .map((template) => {
+        const category = categoryMap.get(template.categoryId);
+        const size = sizeMap.get(template.postSizeId);
+        const gradient = template.thumbnailColor
+          ? `linear-gradient(135deg, ${template.thumbnailColor[0]}, ${template.thumbnailColor[1]})`
+          : `linear-gradient(135deg, ${template.accent || '#4f46e5'}, rgba(79, 70, 229, 0.32))`;
+        return `
+          <div class="template-card" data-template="${template.id}" style="background:${gradient};">
+            <h3>${template.title}</h3>
+            <p>${template.description || ''}</p>
+            <span class="badge">${category ? category.name : 'Category'} · ${size ? `${size.platform} ${size.label}` : 'Size'}</span>
+          </div>
+        `;
+      })
+      .join('');
+  };
+
+  const renderSavedDesigns = () => {
+    const list = document.getElementById('savedDesignsList');
+    const saved = state.currentUser.savedTemplates || [];
+    if (!saved.length) {
+      list.innerHTML = '<p class="muted">No saved designs yet. Customize a template and save it.</p>';
+      return;
+    }
+    const templateMap = new Map(state.data.templates.map((template) => [template.id, template]));
+    list.innerHTML = saved
+      .slice()
+      .sort((a, b) => new Date(b.updatedAt || b.createdAt) - new Date(a.updatedAt || a.createdAt))
+      .map((design) => {
+        const template = templateMap.get(design.templateId);
+        const title = template ? template.title : design.name;
+        return `
+          <div class="saved-card" data-design="${design.id}">
+            <div>
+              <h4>${title}</h4>
+              <p class="muted">Saved on ${new Date(design.updatedAt || design.createdAt).toLocaleString()}</p>
+            </div>
+            <div class="control-row">
+              <button type="button" class="secondary" data-action="open-design" data-design="${design.id}">Open</button>
+              <button type="button" class="secondary" data-action="delete-design" data-design="${design.id}">Delete</button>
+            </div>
+          </div>
+        `;
+      })
+      .join('');
+  };
+
+  const handleSavedDesignAction = (event) => {
+    const button = event.target.closest('button[data-action]');
+    if (!button) return;
+    const designId = button.dataset.design;
+    const design = (state.currentUser.savedTemplates || []).find((item) => item.id === designId);
+    if (!design) return;
+    if (button.dataset.action === 'open-design') {
+      loadTemplate(design.templateId, { htmlOverride: design.htmlContent, useProfile: false, savedDesignId: design.id });
+      showToast('Saved design loaded.');
+    }
+    if (button.dataset.action === 'delete-design') {
+      state.data = FilignsStorage.updateData((data) => {
+        const user = data.users.find((item) => item.id === state.currentUserId);
+        if (!user) return;
+        user.savedTemplates = (user.savedTemplates || []).filter((item) => item.id !== designId);
+        state.currentUser = user;
+      });
+      renderSavedDesigns();
+      showToast('Saved design deleted.');
+    }
+  };
+
+  const bindAuth = () => {
+    const loginForm = document.getElementById('loginForm');
+    loginForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const username = selectors.loginUser.value.trim();
+      const password = selectors.loginPass.value.trim();
+      const data = FilignsStorage.loadData();
+      const user = data.users.find((item) => item.id === username && item.password === password && item.role === 'user');
+      if (!user) {
+        showToast('Invalid credentials or not a user account.');
+        return;
+      }
+      state.currentUserId = user.id;
+      state.currentUser = user;
+      state.data = data;
+      localStorage.setItem(STORAGE_SESSION_KEY, user.id);
+      document.getElementById('authSection').classList.add('hidden');
+      document.getElementById('appSection').classList.remove('hidden');
+      initializeWorkspace();
+      showToast(`Welcome ${user.name || user.id}!`);
+    });
+  };
+
+  const initializeWorkspace = () => {
+    state.data = FilignsStorage.loadData();
+    state.currentUser = state.data.users.find((user) => user.id === state.currentUserId);
+    populateProfileForm();
+    renderCategoryFilters();
+    renderSizeFilter();
+    selectors.searchTemplate.value = '';
+    selectors.currentCategoryFilter = 'all';
+    document.getElementById('filterAll').classList.add('active');
+    renderTemplates();
+    renderSavedDesigns();
+    populateFontControl();
+  };
+
+  const bindProfileHandlers = () => {
+    selectors.saveProfileBtn.addEventListener('click', () => saveProfile());
+    selectors.resetProfileBtn.addEventListener('click', async () => {
+      selectors.profileName.value = state.currentUser.name || state.currentUser.id;
+      selectors.profileEmail.value = '';
+      selectors.profilePhone.value = '';
+      selectors.profileTagline.value = '';
+      selectors.profileAddress.value = '';
+      selectors.brandPrimary.value = '#1e88e5';
+      selectors.brandSecondary.value = '#f9a825';
+      updateColorSwatches({ colorPrimary: '#1e88e5', colorSecondary: '#f9a825' });
+      document.getElementById('logoUpload').value = '';
+      await saveProfile({ reset: true });
+      showToast('Profile reset to defaults.');
+    });
+    selectors.brandPrimary.addEventListener('input', () => {
+      updateColorSwatches({ colorPrimary: selectors.brandPrimary.value, colorSecondary: selectors.brandSecondary.value });
+      if (state.selectedTemplate) {
+        state.selectedTemplate.canvas.style.setProperty('--brand-primary', selectors.brandPrimary.value);
+      }
+    });
+    selectors.brandSecondary.addEventListener('input', () => {
+      updateColorSwatches({ colorPrimary: selectors.brandPrimary.value, colorSecondary: selectors.brandSecondary.value });
+      if (state.selectedTemplate) {
+        state.selectedTemplate.canvas.style.setProperty('--brand-secondary', selectors.brandSecondary.value);
+      }
+    });
+  };
+
+  const bindTemplateFilters = () => {
+    document.getElementById('categoryFilters').addEventListener('click', (event) => {
+      const pill = event.target.closest('.pill');
+      if (!pill) return;
+      document.querySelectorAll('#categoryFilters .pill').forEach((node) => node.classList.remove('active'));
+      document.getElementById('filterAll').classList.remove('active');
+      pill.classList.add('active');
+      selectors.currentCategoryFilter = pill.dataset.filter;
+      renderTemplates();
+    });
+
+    document.getElementById('filterAll').addEventListener('click', () => {
+      selectors.currentCategoryFilter = 'all';
+      document.querySelectorAll('#categoryFilters .pill').forEach((node) => node.classList.remove('active'));
+      document.getElementById('filterAll').classList.add('active');
+      renderTemplates();
+    });
+
+    selectors.sizeFilter.addEventListener('change', renderTemplates);
+    selectors.searchTemplate.addEventListener('input', renderTemplates);
+
+    document.getElementById('templateList').addEventListener('click', (event) => {
+      const card = event.target.closest('.template-card');
+      if (!card) return;
+      loadTemplate(card.dataset.template);
+    });
+  };
+
+  const bindEditorControls = () => {
+    selectors.fontFamily.addEventListener('change', () => {
+      if (!state.selectedElement) return;
+      const font = selectors.fontFamily.value;
+      state.selectedElement.style.fontFamily = `'${font}', sans-serif`;
+    });
+
+    selectors.fontSize.addEventListener('input', () => {
+      if (!state.selectedElement) return;
+      const size = selectors.fontSize.value;
+      selectors.fontSizeLabel.textContent = `${size}px`;
+      state.selectedElement.style.fontSize = `${size}px`;
+    });
+
+    selectors.fontColor.addEventListener('input', () => {
+      if (!state.selectedElement) return;
+      state.selectedElement.style.color = selectors.fontColor.value;
+    });
+
+    selectors.boldBtn.addEventListener('click', () => {
+      if (!state.selectedElement) return;
+      const isActive = selectors.boldBtn.classList.toggle('active');
+      state.selectedElement.style.fontWeight = isActive ? '700' : '400';
+    });
+
+    selectors.italicBtn.addEventListener('click', () => {
+      if (!state.selectedElement) return;
+      const isActive = selectors.italicBtn.classList.toggle('active');
+      state.selectedElement.style.fontStyle = isActive ? 'italic' : 'normal';
+    });
+
+    selectors.alignmentButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        if (!state.selectedElement) return;
+        selectors.alignmentButtons.forEach((btn) => btn.classList.remove('active'));
+        button.classList.add('active');
+        state.selectedElement.style.textAlign = button.dataset.align;
+      });
+    });
+
+    selectors.resetTemplateBtn.addEventListener('click', () => {
+      if (!state.selectedTemplate) return;
+      loadTemplate(state.selectedTemplate.template.id);
+    });
+
+    selectors.saveDraftBtn.addEventListener('click', () => {
+      if (!state.selectedTemplate) {
+        showToast('Select a template first.');
+        return;
+      }
+      const htmlContent = state.selectedTemplate.container.innerHTML;
+      const design = {
+        id: FilignsStorage.generateId('design'),
+        templateId: state.selectedTemplate.template.id,
+        name: state.selectedTemplate.template.title,
+        htmlContent,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+      state.data = FilignsStorage.updateData((data) => {
+        const user = data.users.find((item) => item.id === state.currentUserId);
+        if (!user) return;
+        user.savedTemplates = user.savedTemplates || [];
+        user.savedTemplates.push(design);
+        state.currentUser = user;
+      });
+      renderSavedDesigns();
+      showToast('Design saved. Find it in "My saved designs".');
+    });
+
+    selectors.exportBtn.addEventListener('click', async () => {
+      if (!state.selectedTemplate) {
+        showToast('Select a template to export.');
+        return;
+      }
+      const target = state.selectedTemplate.canvas;
+      if (!window.html2canvas) {
+        showToast('Export library not loaded.');
+        return;
+      }
+      const canvas = await window.html2canvas(target, { backgroundColor: null, scale: 2 });
+      const link = document.createElement('a');
+      const fileName = `${state.selectedTemplate.template.title.replace(/\s+/g, '-')}-${Date.now()}.png`;
+      link.download = fileName;
+      link.href = canvas.toDataURL('image/png');
+      link.click();
+      showToast('PNG downloaded.');
+    });
+
+    selectors.elementImageUpload.addEventListener('change', async () => {
+      if (!state.selectedElement || state.selectedElement.tagName.toLowerCase() !== 'img') return;
+      const file = selectors.elementImageUpload.files[0];
+      if (!file) return;
+      const dataUrl = await readFileAsDataURL(file).catch(() => null);
+      if (dataUrl) {
+        state.selectedElement.src = dataUrl;
+        showToast('Image updated.');
+      }
+      selectors.elementImageUpload.value = '';
+    });
+  };
+
+  const bindSavedDesigns = () => {
+    document.getElementById('savedDesignsList').addEventListener('click', handleSavedDesignAction);
+  };
+
+  const restoreSession = () => {
+    const userId = localStorage.getItem(STORAGE_SESSION_KEY);
+    if (!userId) return;
+    const data = FilignsStorage.loadData();
+    const user = data.users.find((item) => item.id === userId && item.role === 'user');
+    if (!user) return;
+    state.currentUserId = user.id;
+    state.currentUser = user;
+    state.data = data;
+    document.getElementById('authSection').classList.add('hidden');
+    document.getElementById('appSection').classList.remove('hidden');
+    initializeWorkspace();
+    showToast(`Welcome back, ${user.name || user.id}!`);
+  };
+
+  const init = () => {
+    FilignsStorage.ensureData();
+    selectors.loginUser = document.getElementById('loginUser');
+    selectors.loginPass = document.getElementById('loginPass');
+    selectors.profileName = document.getElementById('profileName');
+    selectors.profileEmail = document.getElementById('profileEmail');
+    selectors.profilePhone = document.getElementById('profilePhone');
+    selectors.profileTagline = document.getElementById('profileTagline');
+    selectors.profileAddress = document.getElementById('profileAddress');
+    selectors.brandPrimary = document.getElementById('brandPrimary');
+    selectors.brandSecondary = document.getElementById('brandSecondary');
+    selectors.saveProfileBtn = document.getElementById('saveProfileBtn');
+    selectors.resetProfileBtn = document.getElementById('resetProfileBtn');
+    selectors.logoutBtn = document.getElementById('logoutBtn');
+    selectors.sizeFilter = document.getElementById('sizeFilter');
+    selectors.searchTemplate = document.getElementById('searchTemplate');
+    selectors.canvasStage = document.getElementById('canvasStage');
+    selectors.fontFamily = document.getElementById('fontFamilyControl');
+    selectors.fontSize = document.getElementById('fontSizeControl');
+    selectors.fontColor = document.getElementById('fontColorControl');
+    selectors.fontSizeLabel = document.getElementById('fontSizeLabel');
+    selectors.boldBtn = document.getElementById('boldBtn');
+    selectors.italicBtn = document.getElementById('italicBtn');
+    selectors.alignmentButtons = Array.from(document.querySelectorAll('[data-align]'));
+    selectors.resetTemplateBtn = document.getElementById('resetTemplateBtn');
+    selectors.saveDraftBtn = document.getElementById('saveDraftBtn');
+    selectors.exportBtn = document.getElementById('exportBtn');
+    selectors.elementImageUpload = document.getElementById('elementImageUpload');
+    selectors.imageControl = document.getElementById('imageControl');
+    if (selectors.imageControl) selectors.imageControl.classList.add('hidden');
+
+    bindAuth();
+    bindProfileHandlers();
+    bindTemplateFilters();
+    bindEditorControls();
+    bindSavedDesigns();
+    selectors.logoutBtn.addEventListener('click', logout);
+
+    restoreSession();
+  };
+
+  return { init };
+})();
+
+document.addEventListener('DOMContentLoaded', () => {
+  FilignsApp.init();
+});

--- a/assets/storage.js
+++ b/assets/storage.js
@@ -1,0 +1,148 @@
+const FilignsStorage = (() => {
+  const STORAGE_KEY = 'filigns_center_cms_v1';
+
+  const defaultLogo = `data:image/svg+xml;base64,${btoa(`<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect width="200" height="200" rx="28" fill="#1e88e5"/><text x="50%" y="54%" dominant-baseline="middle" text-anchor="middle" font-size="82" font-family="Poppins, Arial" fill="#fff">F</text><text x="50%" y="78%" dominant-baseline="middle" text-anchor="middle" font-size="24" font-family="Poppins, Arial" fill="#bbdefb">Center</text></svg>`)}`;
+
+  const defaultData = {
+    postSizes: [
+      { id: 'insta-square', platform: 'Instagram', label: 'Square Post', width: 1080, height: 1080 },
+      { id: 'insta-story', platform: 'Instagram', label: 'Story', width: 1080, height: 1920 },
+      { id: 'yt-thumb', platform: 'YouTube', label: 'Thumbnail', width: 1280, height: 720 },
+      { id: 'fb-cover', platform: 'Facebook', label: 'Page Cover', width: 1640, height: 924 }
+    ],
+    categories: [
+      { id: 'cat-social', name: 'Social Media Posts', description: 'Square and story creatives for Instagram & Facebook.', postSizeIds: ['insta-square', 'insta-story'] },
+      { id: 'cat-video', name: 'Video Platforms', description: 'Thumbnails for YouTube and other platforms.', postSizeIds: ['yt-thumb'] }
+    ],
+    templates: [
+      {
+        id: 'temp-fashion',
+        title: 'Fashion Sale Promo',
+        categoryId: 'cat-social',
+        postSizeId: 'insta-square',
+        description: 'Bold gradients and placeholders for store info.',
+        accent: '#ff6b6b',
+        fonts: ['Poppins', 'Montserrat', 'Nunito'],
+        thumbnailColor: ['#ff6b6b', '#ffa36c'],
+        placeholders: ['name', 'phone', 'email', 'address', 'logo'],
+        htmlContent: `<div class="fc-canvas fc-square" style="--accent-color:#ff6b6b; --secondary-color:#ffe66d;">
+  <div class="fc-header">
+    <div class="fc-logo-wrapper">
+      <img data-placeholder="logo" src="${defaultLogo}" alt="Brand Logo" class="fc-logo" />
+    </div>
+    <div class="fc-headline">
+      <p class="fc-tag" data-editable="true">Exclusive Offer</p>
+      <h1 data-placeholder="name" data-editable="true">Filigns Center</h1>
+      <p data-editable="true">Bring your creative ideas to life!</p>
+    </div>
+  </div>
+  <div class="fc-body">
+    <div class="fc-sale-block">
+      <span class="fc-sale-label" data-editable="true">FLAT</span>
+      <span class="fc-sale-value" data-editable="true">50% OFF</span>
+    </div>
+    <div class="fc-contact">
+      <p><span class="fc-contact-label">Call:</span> <span data-placeholder="phone" data-editable="true">+91 98765 43210</span></p>
+      <p><span class="fc-contact-label">Email:</span> <span data-placeholder="email" data-editable="true">hello@filignscenter.com</span></p>
+      <p><span class="fc-contact-label">Visit:</span> <span data-placeholder="address" data-editable="true">123 Creative Street, Mumbai</span></p>
+    </div>
+  </div>
+  <div class="fc-footer" data-editable="true">
+    Customize fonts, colors, and logo to match your brand instantly.
+  </div>
+</div>`
+      },
+      {
+        id: 'temp-youtube',
+        title: 'YouTube Episode Highlight',
+        categoryId: 'cat-video',
+        postSizeId: 'yt-thumb',
+        description: 'Dynamic layout with bold typography for video thumbnails.',
+        accent: '#673ab7',
+        fonts: ['Bebas Neue', 'Poppins', 'Roboto'],
+        thumbnailColor: ['#673ab7', '#9575cd'],
+        placeholders: ['name', 'logo', 'tagline'],
+        htmlContent: `<div class="fc-canvas fc-yt" style="--accent-color:#673ab7; --secondary-color:#ffd54f;">
+  <div class="fc-yt-left">
+    <div class="fc-yt-badge" data-editable="true">NEW EPISODE</div>
+    <h2 data-placeholder="name" data-editable="true">Filigns Center Podcast</h2>
+    <p data-placeholder="tagline" data-editable="true">Design strategies & marketing hacks</p>
+    <div class="fc-yt-meta" data-editable="true">
+      Streaming this Friday • Don’t miss it
+    </div>
+  </div>
+  <div class="fc-yt-right">
+    <div class="fc-yt-circle"></div>
+    <img data-placeholder="logo" src="${defaultLogo}" alt="Channel Logo" class="fc-yt-logo" />
+  </div>
+</div>`
+      }
+    ],
+    users: [
+      { id: 'admin', name: 'Super Admin', role: 'admin', password: 'admin123' },
+      {
+        id: 'demo',
+        name: 'Demo User',
+        role: 'user',
+        password: 'demo123',
+        profile: {
+          name: 'Filigns Center',
+          email: 'hello@filignscenter.com',
+          phone: '+91 98765 43210',
+          address: '123 Creative Street, Mumbai',
+          tagline: 'Your design partner',
+          colorPrimary: '#1e88e5',
+          colorSecondary: '#f9a825',
+          logo: defaultLogo
+        },
+        savedTemplates: []
+      }
+    ],
+    settings: {
+      fonts: ['Poppins', 'Montserrat', 'Nunito', 'Inter', 'Bebas Neue', 'Roboto', 'Lato']
+    }
+  };
+
+  function ensureData() {
+    const existing = localStorage.getItem(STORAGE_KEY);
+    if (!existing) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(defaultData));
+    }
+  }
+
+  function loadData() {
+    ensureData();
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY));
+    } catch (error) {
+      console.error('Failed to parse data store, resetting.', error);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(defaultData));
+      return JSON.parse(JSON.stringify(defaultData));
+    }
+  }
+
+  function saveData(data) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  }
+
+  function updateData(updater) {
+    const data = loadData();
+    const cloned = structuredClone ? structuredClone(data) : JSON.parse(JSON.stringify(data));
+    updater(cloned);
+    saveData(cloned);
+    return cloned;
+  }
+
+  function generateId(prefix) {
+    return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  return {
+    ensureData,
+    loadData,
+    saveData,
+    updateData,
+    generateId,
+    defaultLogo
+  };
+})();

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,635 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Montserrat:wght@500;600;700&family=Poppins:wght@400;500;600;700&family=Nunito:wght@400;600;700&family=Roboto:wght@400;500;700&family=Lato:wght@400;600;700&family=Bebas+Neue&display=swap');
+
+:root {
+  color-scheme: light;
+  --bg: #f3f4f6;
+  --surface: #ffffff;
+  --surface-alt: #f9fafb;
+  --text: #111827;
+  --text-muted: #4b5563;
+  --primary: #4f46e5;
+  --primary-dark: #4338ca;
+  --border: #e5e7eb;
+  --radius-lg: 18px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+  --shadow-sm: 0 12px 32px rgba(15, 23, 42, 0.08);
+  --shadow-lg: 0 20px 45px rgba(15, 23, 42, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  font-family: 'Inter', 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+header {
+  background: linear-gradient(135deg, #312e81, #4f46e5, #7c3aed);
+  color: #fff;
+  padding: 28px 36px 40px;
+  box-shadow: var(--shadow-lg);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+header .brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+header .brand-logo {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.18);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: 0.08em;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 26px;
+  letter-spacing: -0.01em;
+}
+
+header p {
+  margin: 6px 0 0;
+  color: rgba(255, 255, 255, 0.82);
+  max-width: 620px;
+  font-weight: 400;
+}
+
+main {
+  padding: 36px;
+  display: grid;
+  gap: 24px;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  box-shadow: var(--shadow-sm);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+button {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 12px 20px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  background: var(--primary-dark);
+  box-shadow: 0 10px 18px rgba(79, 70, 229, 0.2);
+}
+
+button.secondary {
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  box-shadow: none;
+}
+
+button.secondary:hover {
+  background: var(--surface-alt);
+}
+
+input, select, textarea {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  font-size: 15px;
+  background: var(--surface-alt);
+  font-family: inherit;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus, select:focus, textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.12);
+}
+
+.form-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.form-grid.two {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-row label {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.auth-card {
+  max-width: 420px;
+  margin: 0 auto;
+  text-align: center;
+  display: grid;
+  gap: 24px;
+}
+
+.auth-card h2 {
+  margin: 0;
+  font-size: 24px;
+}
+
+.helper-text {
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+#appSection {
+  display: grid;
+  gap: 24px;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  gap: 24px;
+  align-items: flex-start;
+}
+
+.profile-card {
+  position: sticky;
+  top: 128px;
+}
+
+.template-panel {
+  display: grid;
+  gap: 24px;
+}
+
+.template-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.pill {
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  font-size: 14px;
+  background: var(--surface-alt);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pill.active {
+  background: rgba(79, 70, 229, 0.12);
+  color: var(--primary);
+  border-color: rgba(79, 70, 229, 0.24);
+}
+
+.template-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.template-card {
+  border-radius: var(--radius-lg);
+  background: linear-gradient(140deg, rgba(79, 70, 229, 0.12), rgba(79, 70, 229, 0.22));
+  padding: 20px;
+  display: grid;
+  gap: 14px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.template-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-sm);
+  border-color: rgba(79, 70, 229, 0.2);
+}
+
+.template-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(17, 24, 39, 0.08) 100%);
+  pointer-events: none;
+}
+
+.template-card h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.template-card p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.badge {
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(15, 23, 42, 0.12);
+}
+
+#canvasStage {
+  background: repeating-conic-gradient(#f3f4f6 0deg 90deg, #e5e7eb 90deg 180deg);
+  background-size: 24px 24px;
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  min-height: 420px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+}
+
+.canvas-wrapper {
+  width: 100%;
+  max-width: 620px;
+  position: relative;
+}
+
+.canvas-wrapper .fc-canvas {
+  background: #fff;
+  border-radius: 24px;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.14);
+  overflow: hidden;
+}
+
+.editor-controls {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  align-items: center;
+}
+
+.editor-controls label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.editor-controls .control {
+  display: grid;
+  gap: 8px;
+}
+
+.control-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+button.icon {
+  padding: 10px 14px;
+  background: var(--surface-alt);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  font-weight: 600;
+}
+
+button.icon.active {
+  background: rgba(79, 70, 229, 0.15);
+  border-color: rgba(79, 70, 229, 0.22);
+  color: var(--primary);
+}
+
+.selected-element {
+  outline: 3px solid rgba(79, 70, 229, 0.45);
+  outline-offset: 3px;
+  border-radius: 6px;
+}
+
+#savedDesignsList {
+  display: grid;
+  gap: 12px;
+}
+
+.saved-card {
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.saved-card h4 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.toast {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  padding: 16px 20px;
+  background: var(--text);
+  color: #fff;
+  border-radius: 999px;
+  box-shadow: var(--shadow-lg);
+  opacity: 0;
+  transform: translateY(20px);
+  transition: all 0.3s ease;
+  z-index: 100;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Template specific styling */
+.fc-canvas {
+  display: flex;
+  flex-direction: column;
+  padding: 38px;
+  gap: 18px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(245, 245, 245, 0.9));
+}
+
+.fc-square {
+  aspect-ratio: 1 / 1;
+}
+
+.fc-header {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+}
+
+.fc-logo-wrapper {
+  width: 92px;
+  height: 92px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.9);
+  display: grid;
+  place-items: center;
+  border: 2px solid rgba(0, 0, 0, 0.05);
+}
+
+.fc-logo {
+  width: 70px;
+  height: 70px;
+  object-fit: cover;
+  border-radius: 16px;
+}
+
+.fc-headline h1 {
+  margin: 0;
+  font-family: 'Poppins', sans-serif;
+  font-size: 34px;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+
+.fc-headline p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+}
+
+.fc-tag {
+  display: inline-flex;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 107, 107, 0.12);
+  color: #d90429;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.fc-body {
+  display: grid;
+  gap: 20px;
+}
+
+.fc-sale-block {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.fc-sale-label {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.fc-sale-value {
+  font-size: 48px;
+  font-weight: 800;
+  color: var(--accent-color);
+  font-family: 'Montserrat', sans-serif;
+}
+
+.fc-contact {
+  display: grid;
+  gap: 6px;
+  font-size: 15px;
+}
+
+.fc-contact-label {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.fc-footer {
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(255, 107, 107, 0.08);
+  color: #9b1c31;
+  font-weight: 600;
+  text-align: center;
+}
+
+.fc-yt {
+  aspect-ratio: 16 / 9;
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  background: linear-gradient(135deg, rgba(103, 58, 183, 0.88), rgba(63, 81, 181, 0.92));
+  color: #fff;
+  position: relative;
+  overflow: hidden;
+}
+
+.fc-yt-left {
+  display: grid;
+  gap: 16px;
+  z-index: 2;
+}
+
+.fc-yt-badge {
+  display: inline-flex;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.fc-yt-left h2 {
+  margin: 0;
+  font-family: 'Bebas Neue', cursive;
+  font-size: clamp(38px, 5vw, 56px);
+  letter-spacing: 0.02em;
+}
+
+.fc-yt-left p {
+  margin: 0;
+  font-size: 18px;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.fc-yt-meta {
+  font-size: 15px;
+  background: rgba(255, 255, 255, 0.12);
+  padding: 12px 16px;
+  border-radius: 14px;
+}
+
+.fc-yt-right {
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+
+.fc-yt-circle {
+  position: absolute;
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(circle, rgba(255, 213, 79, 0.7) 0%, rgba(255, 213, 79, 0) 70%);
+  border-radius: 50%;
+  filter: blur(0px);
+}
+
+.fc-yt-logo {
+  width: 180px;
+  height: 180px;
+  object-fit: cover;
+  border-radius: 50%;
+  border: 6px solid rgba(255, 255, 255, 0.6);
+  z-index: 2;
+}
+
+.brand-colors {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.brand-colors .swatch {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  border: 2px solid rgba(0, 0, 0, 0.08);
+}
+
+.profile-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.muted {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+@media (max-width: 1200px) {
+  header {
+    padding: 24px 24px 32px;
+  }
+
+  main {
+    padding: 24px;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-card {
+    position: relative;
+    top: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  header h1 {
+    font-size: 22px;
+  }
+
+  header p {
+    font-size: 14px;
+  }
+
+  main {
+    padding: 20px 16px 80px;
+  }
+
+  .card {
+    padding: 22px;
+  }
+
+  .template-list {
+    grid-template-columns: 1fr;
+  }
+
+  .editor-controls {
+    grid-template-columns: 1fr;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FilignsCenter Creator Portal</title>
+    <link rel="stylesheet" href="assets/style.css" />
+    <script defer src="assets/storage.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+    <script defer src="assets/app.js"></script>
+  </head>
+  <body>
+    <header>
+      <div class="brand">
+        <div class="brand-logo">FC</div>
+        <div>
+          <h1>FilignsCenter Template Studio</h1>
+          <p>
+            Category-wise templates, automatic placeholder mapping, and full design
+            control tailored for every FilignsCenter customer.
+          </p>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section id="authSection" class="card auth-card">
+        <div>
+          <h2>Login to your workspace</h2>
+          <p class="helper-text">
+            Use the credentials shared by your FilignsCenter admin. Demo account:
+            <strong>demo / demo123</strong>
+          </p>
+        </div>
+        <form id="loginForm" class="form-grid">
+          <div class="form-row">
+            <label for="loginUser">User ID</label>
+            <input id="loginUser" name="loginUser" placeholder="e.g. filigns_user" required />
+          </div>
+          <div class="form-row">
+            <label for="loginPass">Password</label>
+            <input id="loginPass" name="loginPass" type="password" placeholder="••••••" required />
+          </div>
+          <button type="submit">Sign in</button>
+        </form>
+        <p class="helper-text">
+          Admins can manage credentials, categories and templates from the
+          <a href="admin.html">admin panel</a>.
+        </p>
+      </section>
+
+      <section id="appSection" class="hidden">
+        <div class="dashboard-grid">
+          <aside class="card profile-card">
+            <div class="profile-header">
+              <h2>Brand profile</h2>
+              <p class="muted">
+                Update details once and they will auto-fill in every template.
+              </p>
+            </div>
+            <form id="profileForm" class="form-grid">
+              <div class="form-row">
+                <label for="profileName">Brand / Contact name</label>
+                <input id="profileName" name="profileName" placeholder="Filigns Center" />
+              </div>
+              <div class="form-grid two">
+                <div class="form-row">
+                  <label for="profileEmail">Email</label>
+                  <input id="profileEmail" name="profileEmail" type="email" placeholder="hello@brand.com" />
+                </div>
+                <div class="form-row">
+                  <label for="profilePhone">Phone</label>
+                  <input id="profilePhone" name="profilePhone" placeholder="+91 90000 00000" />
+                </div>
+              </div>
+              <div class="form-row">
+                <label for="profileTagline">Tagline</label>
+                <input id="profileTagline" name="profileTagline" placeholder="Add your punchline" />
+              </div>
+              <div class="form-row">
+                <label for="profileAddress">Address</label>
+                <textarea id="profileAddress" name="profileAddress" rows="3" placeholder="Business street, city"></textarea>
+              </div>
+              <div class="form-grid two">
+                <div class="form-row">
+                  <label for="brandPrimary">Brand color (primary)</label>
+                  <input id="brandPrimary" name="brandPrimary" type="color" />
+                </div>
+                <div class="form-row">
+                  <label for="brandSecondary">Brand color (secondary)</label>
+                  <input id="brandSecondary" name="brandSecondary" type="color" />
+                </div>
+              </div>
+              <div class="form-row">
+                <label for="logoUpload">Upload / Replace logo</label>
+                <input id="logoUpload" type="file" accept="image/*" />
+                <p class="helper-text">SVG or PNG recommended • 512px square</p>
+              </div>
+              <div class="profile-actions">
+                <button type="button" id="saveProfileBtn">Save profile</button>
+                <button type="button" class="secondary" id="resetProfileBtn">Reset to defaults</button>
+              </div>
+            </form>
+            <div class="brand-colors">
+              <div class="swatch" id="swatchPrimary"></div>
+              <div class="swatch" id="swatchSecondary"></div>
+              <span class="muted">Live preview colors</span>
+            </div>
+            <div class="profile-actions" style="margin-top: 18px;">
+              <button type="button" class="secondary" id="logoutBtn">Log out</button>
+            </div>
+          </aside>
+
+          <section class="template-panel">
+            <article class="card">
+              <h2>Template gallery</h2>
+              <div class="template-filters">
+                <div class="pill active" data-filter="all" id="filterAll">All categories</div>
+                <div id="categoryFilters" class="pill-group"></div>
+                <select id="sizeFilter">
+                  <option value="all">All post sizes</option>
+                </select>
+                <input id="searchTemplate" placeholder="Search template titles" />
+              </div>
+              <div class="template-list" id="templateList"></div>
+            </article>
+
+            <article class="card">
+              <h2>My saved designs</h2>
+              <p class="muted">
+                Every saved design stores your edits. Re-open to continue customizing
+                or download again anytime.
+              </p>
+              <div id="savedDesignsList"></div>
+            </article>
+
+            <article class="card">
+              <h2>Editor &amp; preview</h2>
+              <div id="canvasStage">
+                <p class="muted">Select a template from the gallery to start editing.</p>
+              </div>
+              <div class="editor-controls" id="editorControls">
+                <div class="control">
+                  <label for="fontFamilyControl">Font family</label>
+                  <select id="fontFamilyControl"></select>
+                </div>
+                <div class="control">
+                  <label for="fontSizeControl">Font size <span id="fontSizeLabel"></span></label>
+                  <input type="range" id="fontSizeControl" min="12" max="96" value="32" />
+                </div>
+                <div class="control">
+                  <label for="fontColorControl">Font color</label>
+                  <input type="color" id="fontColorControl" value="#111827" />
+                </div>
+                <div class="control">
+                  <label>Weight</label>
+                  <div class="control-row">
+                    <button type="button" class="icon" id="boldBtn">B</button>
+                    <button type="button" class="icon" id="italicBtn">I</button>
+                  </div>
+                </div>
+                <div class="control">
+                  <label>Alignment</label>
+                  <div class="control-row">
+                    <button type="button" class="icon" data-align="left">Left</button>
+                    <button type="button" class="icon" data-align="center">Center</button>
+                    <button type="button" class="icon" data-align="right">Right</button>
+                  </div>
+                </div>
+                <div class="control" id="imageControl">
+                  <label for="elementImageUpload">Replace selected image</label>
+                  <input type="file" id="elementImageUpload" accept="image/*" />
+                </div>
+                <div class="control">
+                  <label>Quick actions</label>
+                  <div class="control-row">
+                    <button type="button" class="secondary" id="resetTemplateBtn">Reapply profile</button>
+                    <button type="button" id="saveDraftBtn">Save design</button>
+                    <button type="button" id="exportBtn">Download PNG</button>
+                  </div>
+                </div>
+              </div>
+            </article>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <div id="toast" class="toast"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- implement a creator portal with login, profile management, gallery filters, WYSIWYG editor and export for FilignsCenter users
- add an admin console for managing users, post sizes, categories and HTML template uploads with live previews
- share a localStorage data layer, seeded templates and responsive styling used by both experiences

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca982c04cc8331846d69ca7e0e6207